### PR TITLE
다형성 코드 공부

### DIFF
--- a/src/test/java/com/practice/impl/JdbcMemberRepository.java
+++ b/src/test/java/com/practice/impl/JdbcMemberRepository.java
@@ -1,0 +1,12 @@
+package com.practice.impl;
+
+import com.practice.inte.MemberRepository;
+
+public class JdbcMemberRepository implements MemberRepository {
+
+    @Override
+    public int save() {
+        System.out.println("jdbc Repository Impl success");
+        return 0;
+    }
+}

--- a/src/test/java/com/practice/impl/MemoryMemberRepository.java
+++ b/src/test/java/com/practice/impl/MemoryMemberRepository.java
@@ -1,0 +1,12 @@
+package com.practice.impl;
+
+import com.practice.inte.MemberRepository;
+
+public class MemoryMemberRepository implements MemberRepository {
+
+    @Override
+    public int save() {
+        System.out.println("memory Repository Impl success");
+        return 0;
+    }
+}

--- a/src/test/java/com/practice/inte/MemberRepository.java
+++ b/src/test/java/com/practice/inte/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.practice.inte;
+
+public interface MemberRepository {
+
+    public int save();
+}

--- a/src/test/java/com/practice/springpra/SolidTest.java
+++ b/src/test/java/com/practice/springpra/SolidTest.java
@@ -1,0 +1,24 @@
+package com.practice.springpra;
+
+import com.practice.impl.JdbcMemberRepository;
+import com.practice.impl.MemoryMemberRepository;
+import com.practice.inte.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SolidTest {
+
+    @Test
+    @DisplayName("다형성 테스트 코드")
+    public void test() {
+
+        /*
+            인터페이스 구현체가 변경될때 클라이언트 코드 (SolidTest.class)가 변경되어야한다.
+            따라서 기존 객체 지향 개념으로는 완벽한 Solid 설계를 할 수 없음. 클라이언트 코드가 변경되기 떄문에
+            이 개념에 스프링이 필요한 것 임.
+         */
+        //MemberRepository memberRepository = new MemoryMemberRepository();
+        MemberRepository memberRepository = new JdbcMemberRepository();
+        memberRepository.save();
+    }
+}

--- a/src/test/java/com/practice/springpra/SpringpraApplicationTests.java
+++ b/src/test/java/com/practice/springpra/SpringpraApplicationTests.java
@@ -9,7 +9,6 @@ class SpringpraApplicationTests {
     @Test
     void contextLoads() {
 
-
     }
 
 }


### PR DESCRIPTION
- 인터페이스 구현체를 통하여 다형성을 이루어냈지만 이러한 코드를 통해서 Solid 법칙 중 OCP에는 위배 된다

- 클라이언트 코드(SolidTest.java)가 변경되었기 때문이다.
- 다형성을 통하여 이러한 완벽한 Solid를 구현할 수 없으므로 스프링이 필요한것임.
@ued123 